### PR TITLE
Improve WhatsApp media error handling

### DIFF
--- a/src/components/chat/FileUpload.tsx
+++ b/src/components/chat/FileUpload.tsx
@@ -153,7 +153,7 @@ export function FileUpload({ onFileUploaded, disabled }: FileUploadProps) {
         fileType: file.type,
         fileSize: file.size,
         storagePath: data.path,
-        downloadUrl: signedUrl || data.path
+        downloadUrl: signedUrl || ""
       });
 
       // Remove from uploading list after short delay


### PR DESCRIPTION
## Summary
- ensure chat attachments always rely on valid signed URLs before sending to WhatsApp and surface friendly errors when URL creation fails
- extract detailed edge-function failure messages so the UI can display meaningful WhatsApp errors instead of the generic non-2xx notice
- avoid keeping storage-relative paths as attachment download URLs after upload

## Testing
- npm run lint *(fails: missing npm dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf61e2fba48320bab782dd02fa60f8