### PR TITLE
Use alternate WhatsApp access token environment variable

### DIFF
--- a/supabase/functions/whatsapp-webhook/index.ts
+++ b/supabase/functions/whatsapp-webhook/index.ts
@@ -2,7 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const VERIFY_TOKEN = Deno.env.get('WHATSAPP_WEBHOOK_VERIFY_TOKEN') || 'TokenVerifyConcep2020';
-const WHATSAPP_ACCESS_TOKEN = Deno.env.get('WHATSAPP_API_TOKEN');
+const WHATSAPP_ACCESS_TOKEN = Deno.env.get('WHATSAPP_ACCESS_TOKEN') || Deno.env.get('WHATSAPP_API_TOKEN');
 
 // Initialize Supabase client
 const supabaseUrl = Deno.env.get('SUPABASE_URL')!;


### PR DESCRIPTION
## Summary
- allow the WhatsApp webhook function to read the WHATSAPP_ACCESS_TOKEN secret when available before falling back to WHATSAPP_API_TOKEN

## Testing
- npm run lint *(fails: missing dependencies because npm install cannot fetch date-fns package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d003f51eb8832090390d1c552fe974