### PR TITLE
Add admin users tab to settings

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -17,6 +17,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useThemeWithDatabase } from "@/hooks/useThemeWithDatabase";
 import { useGradientDatabase } from "@/hooks/useGradientDatabase";
 import { supabase } from "@/integrations/supabase/client";
+import UnifiedUserManagement from "@/pages/UnifiedUserManagement";
 import { 
   Monitor, 
   Sun, 
@@ -208,6 +209,9 @@ export default function Settings() {
 
   // Check if user is admin or Débora to show WhatsApp tab
   const showWhatsAppTab = user?.role === 'admin' || user?.name === 'Débora';
+  const isAdmin = user?.role === 'admin';
+  const totalTabs = 3 + (showWhatsAppTab ? 1 : 0) + (isAdmin ? 1 : 0);
+  const gridColsClass = totalTabs === 5 ? 'grid-cols-5' : totalTabs === 4 ? 'grid-cols-4' : 'grid-cols-3';
 
   return (
     <div className="space-y-6">
@@ -217,7 +221,7 @@ export default function Settings() {
       />
       
       <Tabs defaultValue="profile" className="space-y-4">
-        <TabsList className={`grid w-full ${showWhatsAppTab ? 'grid-cols-4' : 'grid-cols-3'}`}>
+        <TabsList className={`grid w-full ${gridColsClass}`}>
           <TabsTrigger value="profile" className="flex items-center gap-2">
             <User className="size-4" />
             Perfil
@@ -234,6 +238,12 @@ export default function Settings() {
             <TabsTrigger value="whatsapp" className="flex items-center gap-2">
               <MessageSquare className="size-4" />
               WhatsApp
+            </TabsTrigger>
+          )}
+          {isAdmin && (
+            <TabsTrigger value="users" className="flex items-center gap-2">
+              <Shield className="size-4" />
+              Usuários
             </TabsTrigger>
           )}
         </TabsList>
@@ -544,6 +554,12 @@ export default function Settings() {
           <TabsContent value="whatsapp" className="space-y-4">
             <WhatsAppScheduleConfig />
             <WhatsAppAgendaManager />
+          </TabsContent>
+        )}
+
+        {isAdmin && (
+          <TabsContent value="users" className="space-y-4">
+            <UnifiedUserManagement showHeader={false} />
           </TabsContent>
         )}
       </Tabs>

--- a/src/pages/UnifiedUserManagement.tsx
+++ b/src/pages/UnifiedUserManagement.tsx
@@ -44,6 +44,10 @@ interface UnifiedClient {
 
 type UnifiedEntity = UnifiedUser | UnifiedClient;
 
+interface UnifiedUserManagementProps {
+  showHeader?: boolean;
+}
+
 interface EntityStats {
   totalUsers: number;
   totalAdmins: number;
@@ -51,7 +55,7 @@ interface EntityStats {
   clientsBySetor: Record<string, number>;
 }
 
-export default function UnifiedUserManagement() {
+export default function UnifiedUserManagement({ showHeader = true }: UnifiedUserManagementProps) {
   const { user, login, refreshUser } = useAuth();
   const { toast } = useToast();
   
@@ -651,11 +655,13 @@ export default function UnifiedUserManagement() {
   };
 
   return (
-    <div className="space-y-6">
-      <PageHeader 
-        title="Gestão de Usuários e Clientes" 
-        subtitle="Gerencie usuários do sistema e clientes de forma centralizada" 
-      />
+    <div className={cn("space-y-6", !showHeader && "pt-2")}>
+      {showHeader && (
+        <PageHeader
+          title="Gestão de Usuários e Clientes"
+          subtitle="Gerencie usuários do sistema e clientes de forma centralizada"
+        />
+      )}
 
       {/* Cards de estatísticas */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">


### PR DESCRIPTION
## Summary
- expose an optional header toggle on UnifiedUserManagement so it can be embedded without duplicating its title area
- surface a new Users tab inside Settings for administrators and reuse the unified management view without its header
- adjust settings tab layout to account for the conditional WhatsApp and Users tabs

## Testing
- npm run lint *(fails: missing @eslint/js because npm install cannot fetch date-fns from registry due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d005d11ae4832081cc195d5daf7327