### PR TITLE
Fix chat message preview truncation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -322,6 +322,20 @@ All colors MUST be HSL.
 
 @layer utilities {
   .animate-gradient-pan { animation: gradient-pan 12s ease-in-out infinite; background-size: 200% 200%; }
+
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+
+  .line-clamp-3 {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+  }
 }
 
 @keyframes gradient-pan {

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -858,9 +858,9 @@ export default function Chat() {
                           </div>
                           <div className="flex flex-wrap items-center gap-1 text-sm text-muted-foreground mt-1 min-w-0">
                             <Phone className="h-3 w-3 flex-shrink-0" />
-                            <span className="truncate min-w-0">{contact.phone}</span>
+                            <span className="break-all min-w-0">{contact.phone}</span>
                           </div>
-                          <p className="text-sm text-muted-foreground truncate mt-1">
+                          <p className="text-sm text-muted-foreground mt-1 whitespace-normal break-words line-clamp-3">
                             {contact.lastMessage}
                           </p>
                           {contact.lastMessageTime && (


### PR DESCRIPTION
## Summary
- allow chat contact previews to wrap phone numbers instead of forcing an ellipsis
- show up to three lines of the last message preview with a reusable utility class

## Testing
- npm install *(fails: 403 Forbidden fetching date-fns from the registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0152c0d708320bae2310bdf017e82