### PR TITLE
Fix outgoing chat messages clipped by right margin

### DIFF
--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -12,7 +12,7 @@ const ScrollArea = React.forwardRef<
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] scrollbar-gutter-stable">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/src/index.css
+++ b/src/index.css
@@ -337,6 +337,10 @@ All colors MUST be HSL.
     overflow: hidden;
   }
 
+  .scrollbar-gutter-stable {
+    scrollbar-gutter: stable;
+  }
+
   /* Chat message utilities */
   .chat-message-container {
     width: 100%;

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -912,11 +912,11 @@ export default function Chat() {
                 </div>
               </CardHeader>
               
-               {/* Área de Mensagens */}
-               <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-                 <div className="flex-1 min-h-0 overflow-hidden">
-                   <ScrollArea className="h-full px-3 py-4">
-                     <div className="space-y-4 w-full pr-2">
+              {/* Área de Mensagens */}
+              <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+                <div className="flex-1 min-h-0 overflow-hidden">
+                  <ScrollArea className="h-full px-3 py-4">
+                    <div className="space-y-4 w-full pr-6 sm:pr-8 lg:pr-10">
                       {messages.map((message) => (
                          <div
                            key={message.id}


### PR DESCRIPTION
## Summary
- add additional padding to the chat message list to avoid overlapping the vertical scrollbar
- ensure the scroll area viewport reserves gutter space via a reusable utility class
- expose the new scrollbar-gutter helper in the Tailwind utilities layer for reuse

## Testing
- `npm run lint` *(fails: cannot install dependencies because npm install is blocked for date-fns package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d01f5c717883209a52846715a4b7d8