### PR TITLE
Adjust chat media image sizing

### DIFF
--- a/src/components/chat/MediaMessage.tsx
+++ b/src/components/chat/MediaMessage.tsx
@@ -114,10 +114,10 @@ export function MediaMessage({ attachment }: MediaMessageProps) {
       {isImage && (
         <div className="relative group">
           {!imageError ? (
-            <img 
-              src={proxyUrl} 
+            <img
+              src={proxyUrl}
               alt={attachment.fileName}
-              className="w-full h-auto max-h-64 object-cover"
+              className="w-full h-auto max-h-[70vh] object-contain"
               loading="lazy"
               onError={() => setImageError(true)}
             />


### PR DESCRIPTION
## Summary
- update chat media image rendering to use a flexible max height and object-contain so tall images remain fully visible

## Testing
- npm run lint *(fails: missing dependencies; npm install blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d02135bce483209e22e7ee1a05349f