### PR TITLE
Fix clients list loading and add chat conversation cleanup option

### DIFF
--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -115,11 +115,13 @@ export default function Clients() {
     console.log('fetchClientes called, user:', user);
     if (!user) {
       console.log('No user, returning early');
+      setClientes([]);
+      setLoading(false);
       return;
     }
-    
+
+    setLoading(true);
     try {
-      setLoading(true);
       console.log('Fazendo query para buscar clientes...');
       const { data, error } = await supabase
         .from('clients')
@@ -153,8 +155,6 @@ export default function Clients() {
   }, [user]);
 
   useEffect(() => {
-    // Clear localStorage to reset any cached data
-    localStorage.clear();
     fetchClientes();
   }, [fetchClientes]);
 


### PR DESCRIPTION
## Summary
- prevent the clients page from wiping local storage and reset loading state when no authenticated user is present so client records load again
- add a confirmation flow in the chat header that lets operators clear the WhatsApp message history for a contact without removing the contact itself

## Testing
- npm run lint *(fails: missing `@eslint/js` dependency because packages cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d039a020a0832092d944fa135e4e2d