### PR TITLE
Limit chat history local storage cleanup

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -862,8 +862,22 @@ export default function Chat() {
 
   // Carregar contatos inicialmente
   useEffect(() => {
-    // Clear localStorage to reset message history state
-    localStorage.clear();
+    const clearChatHistoryEntries = () => {
+      try {
+        const keysToRemove: string[] = [];
+        for (let index = 0; index < localStorage.length; index += 1) {
+          const key = localStorage.key(index);
+          if (key?.startsWith("read_messages_")) {
+            keysToRemove.push(key);
+          }
+        }
+        keysToRemove.forEach((key) => localStorage.removeItem(key));
+      } catch (error) {
+        console.error("Erro ao limpar histórico do chat:", error);
+      }
+    };
+
+    clearChatHistoryEntries();
     loadWhatsAppContacts();
   }, [loadWhatsAppContacts, user?.id]);
 


### PR DESCRIPTION
## Summary
- replace the global localStorage.clear() in the chat bootstrap effect with selective removal of chat history entries
- keep the chat history reset behavior without wiping unrelated localStorage data so the client tab remains authenticated

## Testing
- npm run lint *(fails: missing npm packages; npm install blocked by registry 403 for date-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68d06eef48248320965e273e5e0741da