### PR TITLE
Add auth readiness flag before redirecting protected routes

### DIFF
--- a/src/hooks/useAuthSession.ts
+++ b/src/hooks/useAuthSession.ts
@@ -3,12 +3,15 @@ import { useAuth } from '@/state/auth';
 import { supabase } from '@/integrations/supabase/client';
 
 export function useAuthSession() {
-  const { user, refreshUser } = useAuth();
+  const { user, refreshUser, isAuthReady } = useAuth();
 
   const verifySession = useCallback(async () => {
+    if (!isAuthReady) {
+      return true;
+    }
     try {
       const { data: { session }, error } = await supabase.auth.getSession();
-      
+
       if (error) {
         console.error('Erro ao verificar sessão:', error);
         return false;
@@ -31,7 +34,7 @@ export function useAuthSession() {
       console.error('Erro inesperado ao verificar sessão:', error);
       return false;
     }
-  }, [user, refreshUser]);
+  }, [user, refreshUser, isAuthReady]);
 
   const refreshSession = useCallback(async () => {
     try {
@@ -57,6 +60,9 @@ export function useAuthSession() {
 
   // Monitora mudanças na sessão a cada navegação
   useEffect(() => {
+    if (!isAuthReady) {
+      return;
+    }
     const checkSession = async () => {
       const isValid = await verifySession();
       if (!isValid && user) {
@@ -66,7 +72,7 @@ export function useAuthSession() {
     };
 
     checkSession();
-  }, [verifySession, refreshSession, user]);
+  }, [verifySession, refreshSession, user, isAuthReady]);
 
   return {
     verifySession,

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -67,7 +67,8 @@ const nav: NavItem[] = [{
 export default function AppLayout() {
   const {
     user,
-    logout
+    logout,
+    isAuthReady
   } = useAuth();
   
   // Initialize gradient system
@@ -81,6 +82,9 @@ export default function AppLayout() {
 
   // Verify session on navigation changes
   useEffect(() => {
+    if (!isAuthReady) {
+      return;
+    }
     console.log('Navigation changed to:', location.pathname);
     const checkSessionOnNavigation = async () => {
       if (user) {
@@ -90,9 +94,9 @@ export default function AppLayout() {
         }
       }
     };
-    
+
     checkSessionOnNavigation();
-  }, [location.pathname, user, verifySession]);
+  }, [location.pathname, user, verifySession, isAuthReady]);
   const items = useMemo(() => {
     let filteredNav = nav;
 


### PR DESCRIPTION
## Summary
- add an `isAuthReady` flag to the auth context and only mark it ready after the initial Supabase session sync completes
- expose the readiness flag to routes and layout logic so protected/admin pages wait for hydration before redirecting
- gate session verification hooks and layout effects on the readiness flag to avoid premature login flows

## Testing
- `npm run lint` *(fails: missing npm dependency @eslint/js and npm install blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d073e69e1483208f3c6bbdf6d949d8