### PR TITLE
Add RLS policy for deleting client contacts

### DIFF
--- a/supabase/migrations/20250922123000_authenticated_delete_client_contacts.sql
+++ b/supabase/migrations/20250922123000_authenticated_delete_client_contacts.sql
@@ -1,0 +1,5 @@
+-- Allow authenticated users to delete client contacts
+CREATE POLICY "Authenticated users can delete client contacts" ON public.client_contacts
+FOR DELETE USING (
+  auth.uid() IS NOT NULL
+);


### PR DESCRIPTION
## Summary
- add a migration that grants authenticated users permission to delete rows from public.client_contacts

## Testing
- not run (supabase CLI unavailable in container, preventing `supabase db push`)

------
https://chatgpt.com/codex/tasks/task_e_68d0844e2d088320bcbee9bd6b99bad7