### PR TITLE
Add project details dialog for user phases

### DIFF
--- a/src/components/projects/PhaseProjectDetailsDialog.tsx
+++ b/src/components/projects/PhaseProjectDetailsDialog.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "@/hooks/use-toast";
+import { ProjectDocuments } from "./ProjectDocuments";
+
+interface ProjectDetails {
+  id: string;
+  title: string;
+  description?: string | null;
+  address?: string | null;
+  status?: string | null;
+  contracted_hours?: number | null;
+  executed_hours?: number | null;
+  created_at?: string | null;
+  client?: {
+    name?: string | null;
+    email?: string | null;
+  } | null;
+}
+
+interface PhaseProjectDetailsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId?: string;
+  projectTitle?: string;
+  phaseName?: string;
+}
+
+export function PhaseProjectDetailsDialog({
+  open,
+  onOpenChange,
+  projectId,
+  projectTitle,
+  phaseName
+}: PhaseProjectDetailsDialogProps) {
+  const [projectDetails, setProjectDetails] = useState<ProjectDetails | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchProjectDetails = async () => {
+      if (!projectId) return;
+
+      setLoading(true);
+      try {
+        const { data, error } = await supabase
+          .from('projects')
+          .select(`
+            id,
+            title,
+            description,
+            address,
+            status,
+            contracted_hours,
+            executed_hours,
+            created_at,
+            client:clients(name, email)
+          `)
+          .eq('id', projectId)
+          .maybeSingle();
+
+        if (error) throw error;
+
+        if (!data) {
+          toast({
+            title: "Projeto não encontrado",
+            description: "Não foi possível localizar os detalhes do projeto.",
+            variant: "destructive"
+          });
+          setProjectDetails(null);
+          return;
+        }
+
+        setProjectDetails(data as ProjectDetails);
+      } catch (error) {
+        console.error('Erro ao carregar detalhes do projeto:', error);
+        toast({
+          title: "Erro",
+          description: "Não foi possível carregar os detalhes do projeto.",
+          variant: "destructive"
+        });
+        setProjectDetails(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (open && projectId) {
+      fetchProjectDetails();
+    }
+
+    if (!open) {
+      setProjectDetails(null);
+      setLoading(false);
+    }
+  }, [open, projectId]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setProjectDetails(null);
+      setLoading(false);
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const contractedHours = projectDetails?.contracted_hours ?? 0;
+  const executedHours = projectDetails?.executed_hours ?? 0;
+  const progressValue = contractedHours > 0
+    ? Math.min((executedHours / contractedHours) * 100, 100)
+    : 0;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{projectDetails?.title || projectTitle || 'Detalhes do Projeto'}</DialogTitle>
+          <DialogDescription>
+            {phaseName ? `Etapa atual: ${phaseName}` : 'Visualização da etapa selecionada'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {projectId ? (
+          <Tabs defaultValue="info" className="mt-4">
+            <TabsList>
+              <TabsTrigger value="info">Informações</TabsTrigger>
+              <TabsTrigger value="documents">Documentos</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="info" className="mt-4">
+              {loading ? (
+                <Card>
+                  <CardContent className="py-10 text-center text-sm text-muted-foreground">
+                    Carregando detalhes do projeto...
+                  </CardContent>
+                </Card>
+              ) : projectDetails ? (
+                <div className="space-y-4">
+                  <Card>
+                    <CardContent className="space-y-4 pt-6">
+                      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="space-y-1">
+                          <p className="text-sm text-muted-foreground">Cliente</p>
+                          <p className="font-medium">
+                            {projectDetails.client?.name || 'Não informado'}
+                          </p>
+                          {projectDetails.client?.email && (
+                            <p className="text-sm text-muted-foreground">
+                              {projectDetails.client.email}
+                            </p>
+                          )}
+                        </div>
+                        {projectDetails.status && (
+                          <Badge variant="outline" className="self-start uppercase">
+                            {projectDetails.status}
+                          </Badge>
+                        )}
+                      </div>
+
+                      {projectDetails.description && (
+                        <div>
+                          <p className="text-sm text-muted-foreground">Descrição</p>
+                          <p className="text-sm leading-relaxed">
+                            {projectDetails.description}
+                          </p>
+                        </div>
+                      )}
+
+                      {projectDetails.address && (
+                        <div>
+                          <p className="text-sm text-muted-foreground">Endereço</p>
+                          <p className="text-sm">{projectDetails.address}</p>
+                        </div>
+                      )}
+
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between text-sm">
+                          <span className="font-medium">Progresso das Horas</span>
+                          <span className="text-muted-foreground">
+                            {executedHours.toFixed(1)}h / {contractedHours.toFixed(1)}h
+                          </span>
+                        </div>
+                        <Progress value={progressValue} />
+                      </div>
+
+                      <div className="grid gap-4 sm:grid-cols-2 text-sm text-muted-foreground">
+                        <div>
+                          <span className="font-medium block text-foreground">Horas Executadas</span>
+                          {executedHours.toFixed(1)}h
+                        </div>
+                        <div>
+                          <span className="font-medium block text-foreground">Horas Contratadas</span>
+                          {contractedHours.toFixed(1)}h
+                        </div>
+                        <div className="sm:col-span-2">
+                          <span className="font-medium block text-foreground">Criado em</span>
+                          {projectDetails.created_at
+                            ? new Date(projectDetails.created_at).toLocaleDateString('pt-BR')
+                            : 'Não informado'}
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </div>
+              ) : (
+                <Card>
+                  <CardContent className="py-10 text-center text-sm text-muted-foreground">
+                    Não foi possível carregar os detalhes do projeto.
+                  </CardContent>
+                </Card>
+              )}
+            </TabsContent>
+
+            <TabsContent value="documents" className="mt-4">
+              <ProjectDocuments projectId={projectId} allowManage={false} />
+            </TabsContent>
+          </Tabs>
+        ) : (
+          <Card className="mt-4">
+            <CardContent className="py-10 text-center text-sm text-muted-foreground">
+              Projeto não vinculado a esta etapa.
+            </CardContent>
+          </Card>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/projects/PhaseTimerCard.tsx
+++ b/src/components/projects/PhaseTimerCard.tsx
@@ -4,16 +4,17 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { 
-  Play, 
-  Square, 
+import {
+  Play,
+  Square,
   Timer,
   Clock,
   AlertTriangle,
   User,
   CheckCircle,
   DollarSign,
-  TrendingDown
+  TrendingDown,
+  Eye
 } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { useAuth } from "@/state/auth";
@@ -41,9 +42,10 @@ interface PhaseTimerCardProps {
   phase: Phase;
   onHoursUpdate: () => void;
   showProjectTitle?: boolean;
+  onViewProject?: (phase: Phase) => void;
 }
 
-export function PhaseTimerCard({ phase, onHoursUpdate, showProjectTitle = false }: PhaseTimerCardProps) {
+export function PhaseTimerCard({ phase, onHoursUpdate, showProjectTitle = false, onViewProject }: PhaseTimerCardProps) {
   const { user } = useAuth();
   const [isRunning, setIsRunning] = useState(false);
   const [elapsedTime, setElapsedTime] = useState(0);
@@ -345,10 +347,23 @@ export function PhaseTimerCard({ phase, onHoursUpdate, showProjectTitle = false 
             )}
           </div>
           
-          <Badge variant="outline" className={getStatusColor()}>
-            {getStatusIcon()}
-            <span className="ml-1">{getStatusLabel()}</span>
-          </Badge>
+          <div className="flex items-center gap-2">
+            {phase.project?.id && onViewProject && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 gap-1"
+                onClick={() => onViewProject(phase)}
+              >
+                <Eye className="h-4 w-4" />
+                Visualizar
+              </Button>
+            )}
+            <Badge variant="outline" className={getStatusColor()}>
+              {getStatusIcon()}
+              <span className="ml-1">{getStatusLabel()}</span>
+            </Badge>
+          </div>
         </div>
 
         {/* Assigned user */}

--- a/src/components/projects/ProjectDocuments.tsx
+++ b/src/components/projects/ProjectDocuments.tsx
@@ -2,16 +2,12 @@ import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { 
-  Upload, 
-  FileText, 
-  Download, 
-  Calendar, 
+import {
+  Upload,
+  FileText,
+  Download,
+  Calendar,
   Trash2,
-  Plus,
-  File,
   Image,
   FileVideo,
   FileArchive
@@ -32,9 +28,10 @@ interface ProjectDocument {
 
 interface ProjectDocumentsProps {
   projectId: string;
+  allowManage?: boolean;
 }
 
-export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
+export function ProjectDocuments({ projectId, allowManage = true }: ProjectDocumentsProps) {
   const { user } = useAuth();
   const [documents, setDocuments] = useState<ProjectDocument[]>([]);
   const [loading, setLoading] = useState(true);
@@ -229,25 +226,27 @@ export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
           <FileText className="h-5 w-5 text-primary" />
           Documentos do Projeto
         </CardTitle>
-        <div className="flex items-center gap-2">
-          <Input
-            type="file"
-            onChange={handleFileUpload}
-            disabled={uploading}
-            className="hidden"
-            id="document-upload"
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => globalThis.document.getElementById('document-upload')?.click()}
-            disabled={uploading}
-            className="gap-2"
-          >
-            <Upload className="h-4 w-4" />
-            {uploading ? 'Enviando...' : 'Adicionar Documento'}
-          </Button>
-        </div>
+        {allowManage && (
+          <div className="flex items-center gap-2">
+            <Input
+              type="file"
+              onChange={handleFileUpload}
+              disabled={uploading}
+              className="hidden"
+              id="document-upload"
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => globalThis.document.getElementById('document-upload')?.click()}
+              disabled={uploading}
+              className="gap-2"
+            >
+              <Upload className="h-4 w-4" />
+              {uploading ? 'Enviando...' : 'Adicionar Documento'}
+            </Button>
+          </div>
+        )}
       </CardHeader>
       <CardContent>
         {documents.length > 0 ? (
@@ -278,14 +277,16 @@ export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
                   >
                     <Download className="h-4 w-4" />
                   </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleDelete(doc)}
-                    className="p-2 text-red-600 hover:text-red-700"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+                  {allowManage && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(doc)}
+                      className="p-2 text-red-600 hover:text-red-700"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
                 </div>
               </div>
             ))}
@@ -297,17 +298,21 @@ export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
             </div>
             <h3 className="font-medium mb-2">Nenhum documento anexado</h3>
             <p className="text-sm text-muted-foreground mb-4">
-              Adicione documentos relacionados ao projeto como plantas, contratos, fotos, etc.
+              {allowManage
+                ? 'Adicione documentos relacionados ao projeto como plantas, contratos, fotos, etc.'
+                : 'Nenhum documento disponível para este projeto no momento.'}
             </p>
-            <Button
-              variant="outline"
-              onClick={() => globalThis.document.getElementById('document-upload')?.click()}
-              disabled={uploading}
-              className="gap-2"
-            >
-              <Upload className="h-4 w-4" />
-              {uploading ? 'Enviando...' : 'Adicionar Primeiro Documento'}
-            </Button>
+            {allowManage && (
+              <Button
+                variant="outline"
+                onClick={() => globalThis.document.getElementById('document-upload')?.click()}
+                disabled={uploading}
+                className="gap-2"
+              >
+                <Upload className="h-4 w-4" />
+                {uploading ? 'Enviando...' : 'Adicionar Primeiro Documento'}
+              </Button>
+            )}
           </div>
         )}
       </CardContent>

--- a/src/components/projects/UserPhasesView.tsx
+++ b/src/components/projects/UserPhasesView.tsx
@@ -8,6 +8,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/state/auth";
 import { toast } from "@/hooks/use-toast";
 import { PhaseTimerCard } from "./PhaseTimerCard";
+import { PhaseProjectDetailsDialog } from "./PhaseProjectDetailsDialog";
 
 interface UserPhase {
   id: string;
@@ -38,6 +39,8 @@ export function UserPhasesView() {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [activeTimers, setActiveTimers] = useState<Set<string>>(new Set());
+  const [selectedPhase, setSelectedPhase] = useState<UserPhase | null>(null);
+  const [isProjectDialogOpen, setIsProjectDialogOpen] = useState(false);
 
   useEffect(() => {
     loadUserPhases();
@@ -136,6 +139,18 @@ export function UserPhasesView() {
   const handleHoursUpdate = () => {
     loadUserPhases();
     checkActiveTimers();
+  };
+
+  const handleViewProject = (phase: UserPhase) => {
+    setSelectedPhase(phase);
+    setIsProjectDialogOpen(true);
+  };
+
+  const handleDialogOpenChange = (open: boolean) => {
+    setIsProjectDialogOpen(open);
+    if (!open) {
+      setSelectedPhase(null);
+    }
   };
 
   const filteredPhases = phases.filter(phase => {
@@ -251,9 +266,10 @@ export function UserPhasesView() {
           {filteredPhases.map((phase) => (
             <PhaseTimerCard
               key={phase.id}
-              phase={{...phase, assigned_to: phase.assigned_to || '', supervised_by: phase.supervised_by || ''}}
+              phase={{ ...phase, assigned_to: phase.assigned_to || '', supervised_by: phase.supervised_by || '' }}
               onHoursUpdate={handleHoursUpdate}
               showProjectTitle={true}
+              onViewProject={() => handleViewProject(phase)}
             />
           ))}
         </div>
@@ -278,6 +294,14 @@ export function UserPhasesView() {
           </CardContent>
         </Card>
       )}
+
+      <PhaseProjectDetailsDialog
+        open={isProjectDialogOpen}
+        onOpenChange={handleDialogOpenChange}
+        projectId={selectedPhase?.project?.id}
+        projectTitle={selectedPhase?.project?.title}
+        phaseName={selectedPhase?.phase_name}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a project view action on phase cards to open detailed project information
- introduce a phase project details dialog with information and documents tabs backed by Supabase
- allow ProjectDocuments to operate in read-only mode for collaborators when managing is not permitted

## Testing
- npm run lint *(fails: missing npm dependencies in execution environment)*
- npm run build *(fails: vite binary unavailable without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d0acb1ae8c832099a9cc3044b4c544