### PR TITLE
feat: enhance financial registration with installments

### DIFF
--- a/src/pages/Financeiro.tsx
+++ b/src/pages/Financeiro.tsx
@@ -29,6 +29,7 @@ import { ptBR } from "date-fns/locale";
 import { supabase } from "@/integrations/supabase/client";
 import { UnifiedFinancialTab } from "@/components/financial/UnifiedFinancialTab";
 import { ClientFinancialTab } from "@/components/financial/ClientFinancialTab";
+import { ExpenseManagement } from "@/components/financial/ExpenseManagement";
 
 /** *********************************************
  *  FinancialCategoryManagement
@@ -805,7 +806,8 @@ export default function Financeiro() {
         </TabsContent>
 
         {/* Cadastro — por último */}
-        <TabsContent value="cadastro">
+        <TabsContent value="cadastro" className="space-y-6">
+          <ExpenseManagement />
           <FinancialCategoryManagement />
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
## Summary
- add support for parceling expenses in the financial registration dialog with validation, Supabase inserts, and user-friendly labels
- display installment previews, disable duplicate submissions, and highlight parcelled records in the expense list
- surface the expense management experience inside the Financeiro "Cadastro" tab alongside the existing category manager

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d309e4afac832083147afd5a517221