### PR TITLE
Add income management and overview filtering

### DIFF
--- a/src/components/financial/ExpenseManagement.tsx
+++ b/src/components/financial/ExpenseManagement.tsx
@@ -36,7 +36,11 @@ interface Expense {
   category?: FinancialCategory;
 }
 
-export function ExpenseManagement() {
+interface ExpenseManagementProps {
+  onDataChange?: () => void;
+}
+
+export function ExpenseManagement({ onDataChange }: ExpenseManagementProps) {
   const { user } = useAuth();
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [categories, setCategories] = useState<FinancialCategory[]>([]);
@@ -129,7 +133,7 @@ export function ExpenseManagement() {
 
       setCategoryForm({ name: "", category_type: "fixo" });
       setCreateCategoryOpen(false);
-      fetchData();
+      await fetchData();
     } catch (error) {
       console.error('Erro ao criar categoria:', error);
       toast({
@@ -253,7 +257,8 @@ export function ExpenseManagement() {
         installmentCount: "1"
       });
       setCreateDialogOpen(false);
-      fetchData();
+      await fetchData();
+      onDataChange?.();
     } catch (error) {
       console.error('Erro ao criar despesa:', error);
       toast({
@@ -280,7 +285,8 @@ export function ExpenseManagement() {
         description: "Despesa excluída com sucesso!"
       });
 
-      fetchData();
+      await fetchData();
+      onDataChange?.();
     } catch (error) {
       console.error('Erro ao excluir despesa:', error);
       toast({
@@ -305,7 +311,8 @@ export function ExpenseManagement() {
         description: "Status atualizado com sucesso!"
       });
 
-      fetchData();
+      await fetchData();
+      onDataChange?.();
     } catch (error) {
       console.error('Erro ao atualizar status:', error);
       toast({

--- a/src/components/financial/IncomeManagement.tsx
+++ b/src/components/financial/IncomeManagement.tsx
@@ -1,0 +1,466 @@
+import { useEffect, useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Plus, DollarSign, Calendar, User2, Trash2 } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "@/hooks/use-toast";
+import { useAuth } from "@/state/auth";
+
+interface ClientOption {
+  id: string;
+  name: string;
+}
+
+type IncomeStatus = "pending" | "paid" | "overdue" | "cancelled";
+
+interface IncomeRecord {
+  id: string;
+  description: string;
+  amount: number;
+  transaction_date: string;
+  status: IncomeStatus;
+  client_id?: string | null;
+  client_name?: string | null;
+  created_at: string;
+}
+
+interface IncomeManagementProps {
+  onDataChange?: () => void;
+}
+
+const STATUS_LABELS: Record<IncomeStatus, string> = {
+  pending: "Pendente",
+  paid: "Recebida",
+  overdue: "Em Atraso",
+  cancelled: "Cancelada",
+};
+
+const STATUS_VARIANTS: Record<IncomeStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  pending: "secondary",
+  paid: "default",
+  overdue: "destructive",
+  cancelled: "outline",
+};
+
+const normalizeStatus = (status?: string | null): IncomeStatus => {
+  if (!status) return "pending";
+  if (status === "completed") return "paid";
+  if (status === "cancelled") return "cancelled";
+  if (status === "paid" || status === "pending" || status === "overdue") {
+    return status;
+  }
+  return "pending";
+};
+
+export function IncomeManagement({ onDataChange }: IncomeManagementProps) {
+  const { user } = useAuth();
+  const [incomes, setIncomes] = useState<IncomeRecord[]>([]);
+  const [clients, setClients] = useState<ClientOption[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [savingIncome, setSavingIncome] = useState(false);
+
+  const [incomeForm, setIncomeForm] = useState({
+    description: "",
+    amount: "",
+    transaction_date: new Date().toISOString().split("T")[0],
+    client_id: "",
+    status: "pending" as IncomeStatus,
+  });
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      const [incomesRes, clientsRes] = await Promise.all([
+        supabase
+          .from("client_financials")
+          .select(`
+            id,
+            description,
+            amount,
+            transaction_date,
+            status,
+            client_id,
+            created_at,
+            client:clients(id, name)
+          `)
+          .eq("transaction_type", "income")
+          .order("transaction_date", { ascending: false }),
+        supabase
+          .from("clients")
+          .select("id, name")
+          .order("name"),
+      ]);
+
+      if (incomesRes.error) throw incomesRes.error;
+      if (clientsRes.error) throw clientsRes.error;
+
+      const normalizedIncomes: IncomeRecord[] = (incomesRes.data || []).map((income: any) => ({
+        id: String(income.id),
+        description: String(income.description),
+        amount: Number(income.amount) || 0,
+        transaction_date: String(income.transaction_date),
+        status: normalizeStatus(income.status),
+        client_id: income.client_id ? String(income.client_id) : null,
+        client_name: income.client?.name ? String(income.client?.name) : null,
+        created_at: String(income.created_at),
+      }));
+
+      setIncomes(normalizedIncomes);
+      setClients((clientsRes.data as ClientOption[]) || []);
+    } catch (error) {
+      console.error("Erro ao carregar receitas:", error);
+      toast({
+        title: "Erro",
+        description: "Não foi possível carregar as receitas.",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const parseAmount = (value: string) => {
+    if (!value) return NaN;
+    const normalized = value.replace(/\./g, "").replace(",", ".");
+    return Number(normalized);
+  };
+
+  const createIncome = async () => {
+    if (savingIncome) return;
+
+    const amountValue = parseAmount(incomeForm.amount);
+    if (!incomeForm.description.trim() || Number.isNaN(amountValue) || amountValue <= 0) {
+      toast({
+        title: "Erro",
+        description: "Informe uma descrição e um valor válido.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!user?.id) {
+      toast({
+        title: "Sessão expirada",
+        description: "Faça login novamente para cadastrar receitas.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const incomeDate = new Date(incomeForm.transaction_date);
+    if (Number.isNaN(incomeDate.getTime())) {
+      toast({
+        title: "Erro",
+        description: "Informe uma data válida.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      setSavingIncome(true);
+      const { error } = await supabase.from("client_financials").insert({
+        transaction_type: "income",
+        description: incomeForm.description.trim(),
+        amount: amountValue,
+        transaction_date: incomeForm.transaction_date,
+        status: incomeForm.status,
+        client_id: incomeForm.client_id || null,
+        created_by: user.id,
+      });
+
+      if (error) throw error;
+
+      toast({
+        title: "Sucesso",
+        description: "Receita criada com sucesso!",
+      });
+
+      setIncomeForm({
+        description: "",
+        amount: "",
+        transaction_date: new Date().toISOString().split("T")[0],
+        client_id: "",
+        status: "pending",
+      });
+      setDialogOpen(false);
+      await fetchData();
+      onDataChange?.();
+    } catch (error) {
+      console.error("Erro ao criar receita:", error);
+      toast({
+        title: "Erro",
+        description: "Não foi possível criar a receita.",
+        variant: "destructive",
+      });
+    } finally {
+      setSavingIncome(false);
+    }
+  };
+
+  const deleteIncome = async (id: string) => {
+    try {
+      const { error } = await supabase
+        .from("client_financials")
+        .delete()
+        .eq("id", id);
+
+      if (error) throw error;
+
+      toast({
+        title: "Sucesso",
+        description: "Receita excluída com sucesso!",
+      });
+
+      await fetchData();
+      onDataChange?.();
+    } catch (error) {
+      console.error("Erro ao excluir receita:", error);
+      toast({
+        title: "Erro",
+        description: "Não foi possível excluir a receita.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const updateIncomeStatus = async (id: string, status: IncomeStatus) => {
+    try {
+      const { error } = await supabase
+        .from("client_financials")
+        .update({ status })
+        .eq("id", id);
+
+      if (error) throw error;
+
+      toast({
+        title: "Sucesso",
+        description: "Status atualizado com sucesso!",
+      });
+
+      await fetchData();
+      onDataChange?.();
+    } catch (error) {
+      console.error("Erro ao atualizar status da receita:", error);
+      toast({
+        title: "Erro",
+        description: "Não foi possível atualizar o status.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const totalPending = useMemo(
+    () => incomes.filter(income => income.status === "pending").reduce((sum, income) => sum + income.amount, 0),
+    [incomes],
+  );
+
+  const totalReceived = useMemo(
+    () => incomes.filter(income => income.status === "paid").reduce((sum, income) => sum + income.amount, 0),
+    [incomes],
+  );
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="h-8 bg-muted rounded" />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {[1, 2, 3].map(item => (
+            <div key={item} className="h-32 bg-muted rounded" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">Receitas Pendentes</p>
+                <p className="text-2xl font-bold text-yellow-600">
+                  R$ {totalPending.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+                </p>
+              </div>
+              <Calendar className="h-8 w-8 text-yellow-600 opacity-80" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">Receitas Recebidas</p>
+                <p className="text-2xl font-bold text-green-600">
+                  R$ {totalReceived.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+                </p>
+              </div>
+              <DollarSign className="h-8 w-8 text-green-600 opacity-80" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">Clientes Relacionados</p>
+                <p className="text-2xl font-bold text-primary">{clients.length}</p>
+              </div>
+              <User2 className="h-8 w-8 text-primary opacity-80" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="flex gap-3">
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger asChild>
+            <Button>
+              <Plus className="h-4 w-4 mr-2" />
+              Nova Receita
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Criar Nova Receita</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div>
+                <Label htmlFor="income_description">Descrição</Label>
+                <Input
+                  id="income_description"
+                  value={incomeForm.description}
+                  onChange={(event) => setIncomeForm(prev => ({ ...prev, description: event.target.value }))}
+                  placeholder="Descrição da receita"
+                />
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="income_amount">Valor</Label>
+                  <Input
+                    id="income_amount"
+                    type="number"
+                    step="0.01"
+                    value={incomeForm.amount}
+                    onChange={(event) => setIncomeForm(prev => ({ ...prev, amount: event.target.value }))}
+                    placeholder="0,00"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="income_date">Data de recebimento</Label>
+                  <Input
+                    id="income_date"
+                    type="date"
+                    value={incomeForm.transaction_date}
+                    onChange={(event) => setIncomeForm(prev => ({ ...prev, transaction_date: event.target.value }))}
+                  />
+                </div>
+              </div>
+              <div>
+                <Label>Cliente</Label>
+                <Select
+                  value={incomeForm.client_id}
+                  onValueChange={(value) => setIncomeForm(prev => ({ ...prev, client_id: value }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecione um cliente (opcional)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">Sem cliente associado</SelectItem>
+                    {clients.map(client => (
+                      <SelectItem key={client.id} value={client.id}>
+                        {client.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Status</Label>
+                <Select
+                  value={incomeForm.status}
+                  onValueChange={(value) => setIncomeForm(prev => ({ ...prev, status: value as IncomeStatus }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="pending">Pendente</SelectItem>
+                    <SelectItem value="paid">Recebida</SelectItem>
+                    <SelectItem value="overdue">Em atraso</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button onClick={createIncome} className="w-full" disabled={savingIncome}>
+                {savingIncome ? "Salvando..." : "Criar Receita"}
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Receitas</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {incomes.map(income => (
+              <div key={income.id} className="flex items-center justify-between p-4 border rounded-lg">
+                <div className="flex-1">
+                  <div className="flex items-center gap-2 mb-2">
+                    <h4 className="font-medium">{income.description}</h4>
+                    <Badge variant={STATUS_VARIANTS[income.status] || "outline"}>
+                      {STATUS_LABELS[income.status]}
+                    </Badge>
+                    {income.client_name && (
+                      <Badge variant="outline">{income.client_name}</Badge>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                    <span>R$ {income.amount.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}</span>
+                    <span>{new Date(income.transaction_date).toLocaleDateString("pt-BR")}</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {income.status !== "paid" && income.status !== "cancelled" && (
+                    <Button size="sm" onClick={() => updateIncomeStatus(income.id, "paid")}>
+                      Marcar como Recebida
+                    </Button>
+                  )}
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => deleteIncome(income.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+            {incomes.length === 0 && (
+              <div className="text-center py-8 text-muted-foreground">
+                Nenhuma receita cadastrada
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an IncomeManagement module to register, list and update client incomes
- extend the Financeiro overview to merge incomes and expenses with a searchable table and aggregated totals
- notify the overview when expenses change so manual expenses are included in metrics

## Testing
- npm run lint *(fails: npm registry returned 403 for date-fns so dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d32ceb4f308320b3c32ec9b2ba9afc