### PR TITLE
Fix empty Select item values

### DIFF
--- a/src/components/financial/IncomeManagement.tsx
+++ b/src/components/financial/IncomeManagement.tsx
@@ -18,6 +18,14 @@ interface ClientOption {
 
 type IncomeStatus = "pending" | "paid" | "overdue" | "cancelled";
 
+interface IncomeFormState {
+  description: string;
+  amount: string;
+  transaction_date: string;
+  client_id: string | null;
+  status: IncomeStatus;
+}
+
 interface IncomeRecord {
   id: string;
   description: string;
@@ -47,6 +55,8 @@ const STATUS_VARIANTS: Record<IncomeStatus, "default" | "secondary" | "destructi
   cancelled: "outline",
 };
 
+const NO_CLIENT_SELECT_VALUE = "no-client";
+
 const normalizeStatus = (status?: string | null): IncomeStatus => {
   if (!status) return "pending";
   if (status === "completed") return "paid";
@@ -65,11 +75,11 @@ export function IncomeManagement({ onDataChange }: IncomeManagementProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [savingIncome, setSavingIncome] = useState(false);
 
-  const [incomeForm, setIncomeForm] = useState({
+  const [incomeForm, setIncomeForm] = useState<IncomeFormState>({
     description: "",
     amount: "",
     transaction_date: new Date().toISOString().split("T")[0],
-    client_id: "",
+    client_id: null,
     status: "pending" as IncomeStatus,
   });
 
@@ -190,7 +200,7 @@ export function IncomeManagement({ onDataChange }: IncomeManagementProps) {
         description: "",
         amount: "",
         transaction_date: new Date().toISOString().split("T")[0],
-        client_id: "",
+        client_id: null,
         status: "pending",
       });
       setDialogOpen(false);
@@ -372,21 +382,26 @@ export function IncomeManagement({ onDataChange }: IncomeManagementProps) {
                 </div>
               </div>
               <div>
-                <Label>Cliente</Label>
-                <Select
-                  value={incomeForm.client_id}
-                  onValueChange={(value) => setIncomeForm(prev => ({ ...prev, client_id: value }))}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione um cliente (opcional)" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="">Sem cliente associado</SelectItem>
-                    {clients.map(client => (
-                      <SelectItem key={client.id} value={client.id}>
-                        {client.name}
-                      </SelectItem>
-                    ))}
+              <Label>Cliente</Label>
+              <Select
+                value={incomeForm.client_id ?? NO_CLIENT_SELECT_VALUE}
+                onValueChange={(value) =>
+                  setIncomeForm(prev => ({
+                    ...prev,
+                    client_id: value === NO_CLIENT_SELECT_VALUE ? null : value,
+                  }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecione um cliente (opcional)" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NO_CLIENT_SELECT_VALUE}>Sem cliente associado</SelectItem>
+                  {clients.map(client => (
+                    <SelectItem key={client.id} value={client.id}>
+                      {client.name}
+                    </SelectItem>
+                  ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/src/components/projects/CreatePhaseDialog.tsx
+++ b/src/components/projects/CreatePhaseDialog.tsx
@@ -15,20 +15,32 @@ interface CreatePhaseDialogProps {
   onPhaseCreated?: () => void;
 }
 
-export function CreatePhaseDialog({ 
-  open, 
-  onOpenChange, 
+type PhaseStatus = "pending" | "in_progress" | "completed" | "cancelled";
+
+interface PhaseFormData {
+  phase_name: string;
+  description: string;
+  allocated_hours: number;
+  status: PhaseStatus;
+  assigned_to: string | null;
+}
+
+const NO_COLLABORATOR_VALUE = "no-collaborator";
+
+export function CreatePhaseDialog({
+  open,
+  onOpenChange,
   projectId,
-  onPhaseCreated 
+  onPhaseCreated
 }: CreatePhaseDialogProps) {
   const [saving, setSaving] = useState(false);
   const [collaborators, setCollaborators] = useState<{id: string, name: string}[]>([]);
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<PhaseFormData>({
     phase_name: "",
     description: "",
     allocated_hours: 0,
-    status: "pending" as 'pending' | 'in_progress' | 'completed' | 'cancelled',
-    assigned_to: ""
+    status: "pending",
+    assigned_to: null
   });
 
   useEffect(() => {
@@ -58,7 +70,7 @@ export function CreatePhaseDialog({
       description: "",
       allocated_hours: 0,
       status: "pending",
-      assigned_to: ""
+      assigned_to: null
     });
   };
 
@@ -192,12 +204,20 @@ export function CreatePhaseDialog({
 
           <div className="space-y-2">
             <Label htmlFor="assigned_to">Colaborador Responsável</Label>
-            <Select value={formData.assigned_to} onValueChange={(value) => setFormData(prev => ({ ...prev, assigned_to: value }))}>
+            <Select
+              value={formData.assigned_to ?? NO_COLLABORATOR_VALUE}
+              onValueChange={(value) =>
+                setFormData(prev => ({
+                  ...prev,
+                  assigned_to: value === NO_COLLABORATOR_VALUE ? null : value,
+                }))
+              }
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Selecione um colaborador" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">Nenhum</SelectItem>
+                <SelectItem value={NO_COLLABORATOR_VALUE}>Nenhum</SelectItem>
                 {collaborators.map((collaborator) => (
                   <SelectItem key={collaborator.id} value={collaborator.id}>
                     {collaborator.name}


### PR DESCRIPTION
## Summary
- replace empty Select item placeholder values with explicit sentinel constants in income and phase dialogs
- type optional form state to map sentinel values back to null when saving

## Testing
- npm run build *(fails: Vite CLI missing because dependencies cannot be installed due to npm registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d33504accc83208da4af0774f40c99