### PR TITLE
Ensure financial record deletions confirm Supabase changes

### DIFF
--- a/src/components/financial/ExpenseManagement.tsx
+++ b/src/components/financial/ExpenseManagement.tsx
@@ -240,9 +240,18 @@ export function ExpenseManagement({
   const deleteExpense = async (id: string) => {
     try {
       const {
+        data,
         error
-      } = await supabase.from('expenses').delete().eq('id', id);
+      } = await supabase.from('expenses').delete().eq('id', id).select('id');
       if (error) throw error;
+      if (!data || data.length === 0) {
+        toast({
+          title: "Erro",
+          description: "Despesa não encontrada ou você não tem permissão para excluir.",
+          variant: "destructive"
+        });
+        return;
+      }
       toast({
         title: "Sucesso",
         description: "Despesa excluída com sucesso!"

--- a/src/components/financial/IncomeManagement.tsx
+++ b/src/components/financial/IncomeManagement.tsx
@@ -220,12 +220,22 @@ export function IncomeManagement({ onDataChange }: IncomeManagementProps) {
 
   const deleteIncome = async (id: string) => {
     try {
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from("client_financials")
         .delete()
-        .eq("id", id);
+        .eq("id", id)
+        .select("id");
 
       if (error) throw error;
+
+      if (!data || data.length === 0) {
+        toast({
+          title: "Erro",
+          description: "Receita não encontrada ou você não tem permissão para excluir.",
+          variant: "destructive",
+        });
+        return;
+      }
 
       toast({
         title: "Sucesso",


### PR DESCRIPTION
## Summary
- check Supabase delete results when removing expenses and show an error toast if nothing was deleted
- apply the same guarded deletion flow to income records so the UI only reports success when the row is actually removed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68d44f00d1d48320bb6e8f8eca04f216