### PR TITLE
Add end date support to agenda events

### DIFF
--- a/src/components/dashboard/widgets/AgendaWidget.tsx
+++ b/src/components/dashboard/widgets/AgendaWidget.tsx
@@ -7,6 +7,7 @@ interface AgendaItem {
   titulo: string;
   descricao?: string;
   data: string;
+  data_fim?: string | null;
   horario: string;
   horario_fim?: string;
   tipo: string;
@@ -21,14 +22,27 @@ interface AgendaWidgetProps {
 }
 
 export function AgendaWidget({ meetings, loading }: AgendaWidgetProps) {
-  const formatDate = (dateStr: string) => {
-    // Parse seguro para evitar offset UTC -> local
+  const formatDate = (dateStr?: string | null) => {
+    if (!dateStr) return '';
     const [yearStr, monthStr, dayStr] = dateStr.split('-');
     const year = Number(yearStr);
-    const month = Number(monthStr) - 1; // Date usa 0-11
+    const month = Number(monthStr) - 1;
     const day = Number(dayStr);
     const d = new Date(year, month, day);
     return d.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' });
+  };
+
+  const formatDateRange = (start: string, end?: string | null) => {
+    const endValue = end || start;
+    if (endValue === start) {
+      return formatDate(start);
+    }
+    return `${formatDate(start)} - ${formatDate(endValue)}`;
+  };
+
+  const isWithinRange = (target: string, start: string, end?: string | null) => {
+    const endValue = end || start;
+    return start <= target && endValue >= target;
   };
 
   const getTipoColor = (tipo: string) => {
@@ -81,8 +95,8 @@ export function AgendaWidget({ meetings, loading }: AgendaWidgetProps) {
               tomorrow.setDate(tomorrow.getDate() + 1);
               const tomorrowStr = tomorrow.toISOString().split('T')[0];
 
-              const todayMeetings = meetings.filter(m => m.data === todayStr);
-              const tomorrowMeetings = meetings.filter(m => m.data === tomorrowStr);
+              const todayMeetings = meetings.filter(m => isWithinRange(todayStr, m.data, m.data_fim));
+              const tomorrowMeetings = meetings.filter(m => isWithinRange(tomorrowStr, m.data, m.data_fim));
 
               return (
                 <>
@@ -92,7 +106,7 @@ export function AgendaWidget({ meetings, loading }: AgendaWidgetProps) {
                         <div key={meeting.id} className="flex items-start responsive-gap-sm p-2 sm:p-3 rounded-lg hover:bg-accent/50 transition-colors border border-border/40">
                           <div className="flex-shrink-0 text-center min-w-0">
                             <div className="text-xs sm:text-sm font-medium text-primary">
-                              {formatDate(meeting.data)}
+                              {formatDateRange(meeting.data, meeting.data_fim)}
                             </div>
                           </div>
                           <div className="flex-1 min-w-0">
@@ -150,7 +164,7 @@ export function AgendaWidget({ meetings, loading }: AgendaWidgetProps) {
                         <div key={meeting.id} className="flex items-start responsive-gap-sm p-2 sm:p-3 rounded-lg hover:bg-accent/50 transition-colors border border-border/40">
                           <div className="flex-shrink-0 text-center min-w-0">
                             <div className="text-xs sm:text-sm font-medium text-primary">
-                              {formatDate(meeting.data)}
+                              {formatDateRange(meeting.data, meeting.data_fim)}
                             </div>
                           </div>
                           <div className="flex-1 min-w-0">

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -22,6 +22,7 @@ export type Database = {
           created_at: string
           created_by: string
           data: string
+          data_fim: string | null
           descricao: string | null
           horario: string
           horario_fim: string | null
@@ -39,6 +40,7 @@ export type Database = {
           created_at?: string
           created_by: string
           data: string
+          data_fim?: string | null
           descricao?: string | null
           horario: string
           horario_fim?: string | null
@@ -56,6 +58,7 @@ export type Database = {
           created_at?: string
           created_by?: string
           data?: string
+          data_fim?: string | null
           descricao?: string | null
           horario?: string
           horario_fim?: string | null

--- a/supabase/migrations/20250907120000_add_end_date_to_agenda.sql
+++ b/supabase/migrations/20250907120000_add_end_date_to_agenda.sql
@@ -1,0 +1,8 @@
+-- Add end date support for agenda events
+ALTER TABLE public.agenda
+  ADD COLUMN IF NOT EXISTS data_fim DATE;
+
+-- Ensure existing records have an end date to avoid null handling on the frontend
+UPDATE public.agenda
+SET data_fim = data
+WHERE data_fim IS NULL;


### PR DESCRIPTION
## Summary
- add end-date handling to agenda scheduling, validation, calendar filtering and detail views
- surface multi-day ranges in the dashboard widget and upcoming lists
- extend Supabase typings and migrations with the new `data_fim` column

## Testing
- npm run lint *(fails: missing @eslint/js due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d44d028fe48320824846a5bc8fc201