### PR TITLE
Add delete policy for client financial records

### DIFF
--- a/supabase/migrations/20250923120000_add_delete_policy_client_financials.sql
+++ b/supabase/migrations/20250923120000_add_delete_policy_client_financials.sql
@@ -1,0 +1,5 @@
+-- Allow authenticated users to delete client financial records
+CREATE POLICY "Authenticated users can delete client financials" ON public.client_financials
+FOR DELETE USING (
+  auth.uid() IS NOT NULL
+);


### PR DESCRIPTION
## Summary
- add a row-level security policy that allows authenticated users to delete records from client_financials

## Testing
- npm run lint *(fails: missing dependency @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d452426080832096a932f936471c82