### PR TITLE
Show only in-progress phases for collaborators

### DIFF
--- a/src/components/dashboard/UserDashboard.tsx
+++ b/src/components/dashboard/UserDashboard.tsx
@@ -25,8 +25,8 @@ export function UserDashboard({ userName }: UserDashboardProps) {
   const navigate = useNavigate();
   const { phases, dailyHours, loading } = useUserProjects();
 
-  const activePhasesCount = phases.filter(phase => 
-    phase.status === 'in_progress' || phase.status === 'pending'
+  const activePhasesCount = phases.filter(phase =>
+    phase.status === 'in_progress'
   ).length;
 
   const quickActions = [


### PR DESCRIPTION
## Summary
- filter `useUserProjects` phase query to only return in-progress items for collaborator profiles
- update the collaborator phases view to enforce the in-progress filter, disable irrelevant status options, and keep active counters aligned
- adjust the dashboard active phase count to consider only in-progress phases

## Testing
- npm run lint *(fails: missing dependencies because the registry blocks date-fns/@eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d7d3f2c883208ca84804df7efea7