### PR TITLE
Fix agenda end date mapping when loading items

### DIFF
--- a/src/pages/Agenda.tsx
+++ b/src/pages/Agenda.tsx
@@ -344,7 +344,7 @@ export default function Agenda() {
       const mappedAgenda =
         (agendaData?.map(item => ({
           ...item,
-          data_fim: item.data, // Usar data como data_fim se não existir
+          data_fim: item.data_fim || item.data, // Usar data como data_fim se não existir
           cliente: item.cliente?.trim().length ? item.cliente : INTERNAL_MEETING_PLACEHOLDER,
           creator_name: profilesMap.get(item.created_by) || 'Usuário desconhecido',
           attendees_display: getAttendeesDisplay(item.collaborators_ids || [], colaboradoresData || [])


### PR DESCRIPTION
## Summary
- ensure agenda entries keep their stored end date when loading data from Supabase
- avoid overwriting multi-day schedules with their start date on page load

## Testing
- `npm run lint` *(fails: missing @eslint/js because npm install cannot access registry)*
- `npm install` *(fails: 403 Forbidden when fetching date-fns from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d8aa59588320a204f467537a407c