### PR TITLE
Handle duplicate client document uploads

### DIFF
--- a/src/pages/ClientDetail.tsx
+++ b/src/pages/ClientDetail.tsx
@@ -333,7 +333,11 @@ export default function ClientDetail() {
       const { data: storageData, error: storageError } = await supabase
         .storage
         .from('client-documents')
-        .upload(fileName, file);
+        .upload(fileName, file, {
+          cacheControl: '3600',
+          upsert: true,
+          contentType: file.type || 'application/octet-stream',
+        });
       if (storageError) throw storageError;
 
       const { error: insertError } = await supabase.from('client_documents').insert({


### PR DESCRIPTION
## Summary
- allow client document uploads to be overwritten without errors by enabling Supabase storage upsert
- ensure uploaded files carry through their content type and cache configuration

## Testing
- `npm run lint` *(fails: missing dependencies due to restricted registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e3a7869c8320a429cdd0ce4dbf02