### PR TITLE
Configure Supabase functions Deno settings

### DIFF
--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "auto"
+}


### PR DESCRIPTION
## Summary
- add a Deno configuration in the Supabase functions folder to enable automatic npm dependency installation

## Testing
- npm run lint *(fails: missing local npm dependency @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e521b9608320a0fb4669630ddfe3