### PR TITLE
Mantém usuários desativados visíveis com ação de ativação

### DIFF
--- a/src/components/users/UserStatusControl.tsx
+++ b/src/components/users/UserStatusControl.tsx
@@ -12,6 +12,7 @@ interface UserStatusControlProps {
   active?: boolean;
   name: string;
   onUpdate: () => void;
+  onStatusChange?: (newActive: boolean) => void;
   canDelete?: boolean;
   canToggleStatus?: boolean;
   disabledReason?: string;
@@ -23,6 +24,7 @@ export function UserStatusControl({
   active = true,
   name,
   onUpdate,
+  onStatusChange,
   canDelete = false,
   canToggleStatus = true,
   disabledReason
@@ -59,8 +61,10 @@ export function UserStatusControl({
 
         toast({
           title: "Sucesso",
-          description: `Usuário ${active ? 'desativado' : 'ativado'} com sucesso`
+          description: `Usuário ${newActiveStatus ? 'ativado' : 'desativado'} com sucesso`
         });
+
+        onStatusChange?.(newActiveStatus);
       } else {
         // Para clientes, não temos campo active, então só permite exclusão
         toast({

--- a/src/pages/UnifiedUserManagement.tsx
+++ b/src/pages/UnifiedUserManagement.tsx
@@ -687,6 +687,16 @@ export default function UnifiedUserManagement({ showHeader = true }: UnifiedUser
             active={isUser ? entity.active : undefined} // Para clientes, não temos campo active
             name={isUser ? entity.full_name : entity.nome}
             onUpdate={fetchAllData}
+            onStatusChange={(newStatus) => {
+              if (entity.type !== 'system_user') return;
+
+              setEntities(prev => prev.map(item => {
+                if (item.type === 'system_user' && item.user_id === entity.user_id) {
+                  return { ...item, active: newStatus };
+                }
+                return item;
+              }));
+            }}
             canToggleStatus={canManageStatus}
             disabledReason={statusDisabledReason}
             canDelete={isMasterAdmin && (isUser ? entity.user_id !== user?.id : true)}


### PR DESCRIPTION
## Summary
- adiciona callback opcional em `UserStatusControl` para atualizar o estado local após alternar o status
- atualiza `UnifiedUserManagement` para manter usuários desativados na lista e exibir corretamente a ação de ativar

## Testing
- npm run lint *(falhou: dependência @eslint/js indisponível no registro padrão)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e6e0d2a883208ba7a817d7f4e435