### PR TITLE
Include inactive system users in management list

### DIFF
--- a/supabase/functions/list-system-users/index.ts
+++ b/supabase/functions/list-system-users/index.ts
@@ -1,0 +1,95 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    if (req.method !== "GET") {
+      return new Response(JSON.stringify({ error: "Method not allowed" }), {
+        status: 405,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+    if (!supabaseUrl || !anonKey || !serviceKey) {
+      console.error("Missing Supabase environment variables");
+      return new Response(JSON.stringify({ error: "Configuração inválida" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const authHeader = req.headers.get("Authorization") ?? "";
+
+    const caller = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const { data: callerUser, error: callerError } = await caller.auth.getUser();
+
+    if (callerError || !callerUser?.user) {
+      return new Response(JSON.stringify({ error: "Não autenticado" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { data: callerProfile, error: profileError } = await caller
+      .from("profiles")
+      .select("role")
+      .eq("user_id", callerUser.user.id)
+      .maybeSingle();
+
+    if (profileError) {
+      console.error("Erro buscando role do solicitante:", profileError);
+      return new Response(JSON.stringify({ error: "Falha ao validar permissões" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const role = callerProfile?.role as string | undefined;
+    if (!(role === "admin" || role === "supervisor")) {
+      return new Response(JSON.stringify({ error: "Sem permissão" }), {
+        status: 403,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const admin = createClient(supabaseUrl, serviceKey);
+    const { data: profiles, error } = await admin
+      .from("profiles")
+      .select("*")
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      console.error("Erro buscando perfis:", error);
+      return new Response(JSON.stringify({ error: "Falha ao carregar usuários" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true, profiles }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("list-system-users error:", error);
+    return new Response(JSON.stringify({ error: (error as Error).message || "Erro interno" }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add list-system-users edge function so admins can retrieve all profiles regardless of active status
- update unified user management screen to use the new function and keep deactivated users visible with reactivation option

## Testing
- npm run lint *(fails: missing dependencies @eslint/js even after npm install due to restricted registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e8ea80508320ae1a63fa7a99768a