### PR TITLE
Fix ProjectDocuments layout and deletion handler

### DIFF
--- a/src/components/projects/ProjectDocuments.tsx
+++ b/src/components/projects/ProjectDocuments.tsx
@@ -218,12 +218,7 @@ export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
     }
   };
 
-  const handleDelete = async () => {
-    if (!documentToDelete) return;
-
-    setDeleting(true);
-    const document = documentToDelete;
-
+  const handleDelete = async (document: ProjectDocument) => {
     try {
       // Deletar do storage
       const { error: storageError } = await supabase.storage
@@ -247,8 +242,6 @@ export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
         title: "Sucesso",
         description: "Documento excluído com sucesso!"
       });
-
-      setDocumentToDelete(null);
     } catch (error) {
       console.error('Erro ao excluir documento:', error);
       toast({
@@ -256,15 +249,12 @@ export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
         description: "Erro ao excluir documento. Tente novamente.",
         variant: "destructive"
       });
-    } finally {
-      setDeleting(false);
     }
   };
 
   if (loading) return <div className="p-6 text-center">Carregando documentos...</div>;
 
   return (
-
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle className="flex items-center gap-2">
@@ -305,7 +295,10 @@ export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
         {documents.length > 0 ? (
           <div className="space-y-3">
             {documents.map(doc => (
-              <div key={doc.id} className="flex items-center justify-between p-4 border border-border/50 rounded-lg hover:border-primary/30 transition-colors">
+              <div
+                key={doc.id}
+                className="flex items-center justify-between p-4 border border-border/50 rounded-lg hover:border-primary/30 transition-colors"
+              >
                 <div className="flex items-center gap-3">
                   <div className="p-2 bg-muted rounded-lg">
                     {getDocumentIcon(doc.document_type)}
@@ -351,7 +344,6 @@ export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
             <p className="text-sm text-muted-foreground mb-4">
               Adicione documentos relacionados ao projeto como plantas, contratos, fotos, etc.
             </p>
-
             <Button
               variant="outline"
               size="sm"
@@ -363,70 +355,8 @@ export function ProjectDocuments({ projectId }: ProjectDocumentsProps) {
               {uploading ? 'Enviando...' : 'Adicionar Documento'}
             </Button>
           </div>
-        </CardHeader>
-        <CardContent>
-          {documents.length > 0 ? (
-            <div className="space-y-3">
-              {documents.map(doc => (
-                <div key={doc.id} className="flex items-center justify-between p-4 border border-border/50 rounded-lg hover:border-primary/30 transition-colors">
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-muted rounded-lg">
-                      {getDocumentIcon(doc.document_type)}
-                    </div>
-                    <div className="flex-1">
-                      <h4 className="font-medium text-sm">{doc.document_name}</h4>
-                      <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                        <span>{formatFileSize(doc.file_size)}</span>
-                        <div className="flex items-center gap-1">
-                          <Calendar className="h-3 w-3" />
-                          {new Date(doc.created_at).toLocaleDateString('pt-BR')}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleDownload(doc)}
-                      className="p-2"
-                    >
-                      <Download className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setDocumentToDelete(doc)}
-                      className="p-2 text-red-600 hover:text-red-700"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="text-center py-8">
-              <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mx-auto mb-4">
-                <FileText className="h-8 w-8 text-muted-foreground" />
-              </div>
-              <h3 className="font-medium mb-2">Nenhum documento anexado</h3>
-              <p className="text-sm text-muted-foreground mb-4">
-                Adicione documentos relacionados ao projeto como plantas, contratos, fotos, etc.
-              </p>
-              <Button
-                variant="outline"
-                onClick={() => globalThis.document.getElementById('document-upload')?.click()}
-                disabled={uploading}
-                className="gap-2"
-              >
-                <Upload className="h-4 w-4" />
-                {uploading ? 'Enviando...' : 'Adicionar Primeiro Documento'}
-              </Button>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </>
+        )}
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- simplify the project document deletion handler to accept the selected document directly
- clean up the ProjectDocuments card structure to remove duplicated markup and ensure proper rendering

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f25188cc83208cc84fc368aef35a