### PR TITLE
Allow POST requests when listing system users

### DIFF
--- a/supabase/functions/list-system-users/index.ts
+++ b/supabase/functions/list-system-users/index.ts
@@ -12,7 +12,8 @@ serve(async (req) => {
   }
 
   try {
-    if (req.method !== "GET") {
+    const allowedMethods = new Set(["GET", "POST"]);
+    if (!allowedMethods.has(req.method)) {
       return new Response(JSON.stringify({ error: "Method not allowed" }), {
         status: 405,
         headers: { ...corsHeaders, "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- allow the list-system-users edge function to handle POST invocations from the frontend so the settings users tab can load data successfully

## Testing
- npm run lint *(fails: missing dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f577aa4483209211f01ac75eae4f