### PR TITLE
Fix finance back button returning to clients tab

### DIFF
--- a/src/pages/Financeiro.tsx
+++ b/src/pages/Financeiro.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { useLocation } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -378,6 +379,7 @@ const categorias = {
 };
 
 export default function Financeiro() {
+  const location = useLocation();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [clients, setClients] = useState<Client[]>([]);
   const [bankAccounts, setBankAccounts] = useState<BankAccount[]>([]);
@@ -389,6 +391,13 @@ export default function Financeiro() {
   const [activeTab, setActiveTab] = useState("overview");
   const [selectedMonth, setSelectedMonth] = useState(new Date());
   const [searchTerm, setSearchTerm] = useState("");
+
+  useEffect(() => {
+    const state = location.state as { activeTab?: string } | null;
+    if (state?.activeTab && state.activeTab !== activeTab) {
+      setActiveTab(state.activeTab);
+    }
+  }, [location.state, activeTab]);
 
   const form = useForm<z.infer<typeof transactionFormSchema>>({
     resolver: zodResolver(transactionFormSchema),


### PR DESCRIPTION
## Summary
- read the active tab for the Financeiro page from the router state so navigation can select the Clientes tab

## Testing
- npm run lint *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/date-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f8b5a64c8320b5bdc9807e3494c5