### PR TITLE
Fix finance tab reset after returning from client details

### DIFF
--- a/src/pages/Financeiro.tsx
+++ b/src/pages/Financeiro.tsx
@@ -398,10 +398,10 @@ export default function Financeiro() {
   useEffect(() => {
     const state = location.state as { activeTab?: string } | null;
 
-    if (state?.activeTab && state.activeTab !== activeTab) {
-      setActiveTab(state.activeTab);
+    if (state?.activeTab) {
+      setActiveTab((currentTab) => (state.activeTab === currentTab ? currentTab : state.activeTab));
     }
-  }, [location.state, activeTab]);
+  }, [location.state]);
 
 
   const form = useForm<z.infer<typeof transactionFormSchema>>({


### PR DESCRIPTION
## Summary
- adjust the Financeiro page to read the active tab from navigation state without locking the tab value
- ensure the active tab can be changed normally after returning from the client financial detail screen

## Testing
- npm run lint *(fails: missing dependency @eslint/js because npm install cannot download date-fns due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fbbc124483209d05e7c5f016668c