### PR TITLE
Fix finance tab reset after returning from client details

### DIFF
--- a/src/pages/ClientFinancialDetail.tsx
+++ b/src/pages/ClientFinancialDetail.tsx
@@ -187,7 +187,7 @@ export default function ClientFinancialDetail() {
         <Button
           variant="outline"
           size="sm"
-          onClick={() => navigate('/financeiro', { state: { activeTab: 'clientes' } })}
+          onClick={() => navigate('/financeiro', { state: { activeTab: 'clients' } })}
           className="flex items-center gap-2"
         >
           <ArrowLeft className="w-4 h-4" />

--- a/src/pages/Financeiro.tsx
+++ b/src/pages/Financeiro.tsx
@@ -398,10 +398,10 @@ export default function Financeiro() {
   useEffect(() => {
     const state = location.state as { activeTab?: string } | null;
 
-    if (state?.activeTab && state.activeTab !== activeTab) {
-      setActiveTab(state.activeTab);
+    if (state?.activeTab) {
+      setActiveTab((currentTab) => (state.activeTab === currentTab ? currentTab : state.activeTab));
     }
-  }, [location.state, activeTab]);
+  }, [location.state]);
 
 
   const form = useForm<z.infer<typeof transactionFormSchema>>({


### PR DESCRIPTION
## Summary
- update the client financial detail back button to navigate with the correct Financeiro tab key
- ensure returning from the client detail focuses the Clientes tab inside Financeiro

## Testing
- npm run lint *(fails: missing dependency @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fbbc124483209d05e7c5f016668c