### PR TITLE
Remove chat media from Supabase storage when clearing history

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -489,6 +489,29 @@ export default function Chat() {
       const messageIds = (messageRows ?? []).map((row) => row.id);
 
       if (messageIds.length > 0) {
+        const {
+          data: attachmentsToDelete,
+          error: fetchAttachmentsError,
+        } = await supabase
+          .from("message_attachments")
+          .select("file_path")
+          .in("message_id", messageIds);
+
+        if (fetchAttachmentsError) throw fetchAttachmentsError;
+
+        const storagePaths = (attachmentsToDelete ?? [])
+          .map((attachment) => attachment.file_path)
+          .filter((path): path is string => Boolean(path));
+
+        if (storagePaths.length > 0) {
+          const uniquePaths = Array.from(new Set(storagePaths));
+          const { error: storageError } = await supabase.storage
+            .from("chat-files")
+            .remove(uniquePaths);
+
+          if (storageError) throw storageError;
+        }
+
         const { error: attachmentsError } = await supabase
           .from("message_attachments")
           .delete()


### PR DESCRIPTION
## Summary
- delete Supabase storage objects for chat attachments when clearing a conversation
- ensure attachment rows are only removed after their files are successfully deleted

## Testing
- npm run lint *(fails: missing dependency @eslint/js due to unavailable npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fd57029c8320befd88e26f7befd6