### PR TITLE
Rename financial categories state in Financeiro

### DIFF
--- a/src/pages/Financeiro.tsx
+++ b/src/pages/Financeiro.tsx
@@ -377,6 +377,7 @@ export default function Financeiro() {
   const [bankAccounts, setBankAccounts] = useState<BankAccount[]>([]);
   const [horasColaboradores, setHorasColaboradores] = useState<HorasColaborador[]>([]);
   const [manualExpenses, setManualExpenses] = useState<ManualExpense[]>([]);
+  const [financialCategories, setFinancialCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<FinanceTab>("overview");
@@ -451,6 +452,13 @@ export default function Financeiro() {
         .order('expense_date', { ascending: false });
       if (expensesError) throw expensesError;
 
+      const { data: categoriesData, error: categoriesError } = await supabase
+        .from('financial_categories')
+        .select('id, name, category_type, created_at, updated_at')
+        .order('category_type', { ascending: true })
+        .order('name', { ascending: true });
+      if (categoriesError) throw categoriesError;
+
       const clientMap = new Map<string, string>();
       (clientsData ?? []).forEach(client => clientMap.set(client.id, client.name));
 
@@ -484,6 +492,14 @@ export default function Financeiro() {
       setClients(clientsData || []);
       setBankAccounts(bankAccountsData || []);
       setManualExpenses(mappedExpenses);
+      const mappedCategories: Category[] = (categoriesData ?? []).map((category: any) => ({
+        id: String(category.id),
+        name: String(category.name),
+        type: category.category_type as Category['type'],
+        created_at: String(category.created_at),
+        updated_at: category.updated_at ? String(category.updated_at) : null,
+      }));
+      setFinancialCategories(mappedCategories);
     } catch (error) {
       console.error('Erro ao carregar dados financeiros:', error);
       toast({
@@ -589,11 +605,11 @@ export default function Financeiro() {
 
   const categoryNameById = useMemo(() => {
     const map = new Map<string, string>();
-    categories.forEach(category => {
+    financialCategories.forEach(category => {
       map.set(category.id, category.name);
     });
     return map;
-  }, [categories]);
+  }, [financialCategories]);
 
   const getTransactionCategoryLabel = useMemo(() => {
     const defaultLabels: Record<string, string> = {


### PR DESCRIPTION
## Summary
- rename the Financeiro page's categories state to financialCategories to avoid name collisions and ensure the memoized map references the correct state
- update the supabase loader and memoized category map to use the renamed state

## Testing
- npm install *(fails: 403 Forbidden when downloading date-fns from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d5017b1338832096e1c828f3fa2a43