### PR TITLE
Fix undefined financial category map

### DIFF
--- a/src/pages/Financeiro.tsx
+++ b/src/pages/Financeiro.tsx
@@ -609,11 +609,11 @@ export default function Financeiro() {
 
   const categoryNameById = useMemo(() => {
     const map = new Map<string, string>();
-    financialCategories.forEach(category => {
+    categories.forEach(category => {
       map.set(category.id, category.name);
     });
     return map;
-  }, [financialCategories]);
+  }, [categories]);
 
   const getTransactionCategoryLabel = useMemo(() => {
     const defaultLabels: Record<string, string> = {


### PR DESCRIPTION
## Summary
- ensure the financial overview uses the loaded category list when building the category lookup map

## Testing
- npm run lint *(fails: missing optional dependency @eslint/js in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d560967a4483208b52a72821376fa6