### PR TITLE
Fix income deletion detection

### DIFF
--- a/src/components/financial/IncomeManagement.tsx
+++ b/src/components/financial/IncomeManagement.tsx
@@ -302,15 +302,15 @@ export function IncomeManagement({ onDataChange }: IncomeManagementProps) {
 
   const deleteIncome = async (id: string) => {
     try {
-      const { data, error } = await supabase
+      const { error, count } = await supabase
         .from("client_financials")
-        .delete()
+        .delete({ count: "exact" })
         .eq("id", id)
-        .select("id");
+        .eq("transaction_type", "income");
 
       if (error) throw error;
 
-      if (!data || data.length === 0) {
+      if (!count) {
         toast({
           title: "Erro",
           description: "Receita não encontrada ou você não tem permissão para excluir.",


### PR DESCRIPTION
## Summary
- ensure income deletions filter by transaction type and rely on Supabase's affected row count
- show a not-found toast only when Supabase reports zero deleted rows

## Testing
- npm run lint *(fails: npm could not install dependencies because the registry returned 403 for date-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68d5697695e48320ac160562a46c25b5