### PR TITLE
Fix income deletion query

### DIFF
--- a/src/components/financial/IncomeManagement.tsx
+++ b/src/components/financial/IncomeManagement.tsx
@@ -309,15 +309,16 @@ export function IncomeManagement({ onDataChange }: IncomeManagementProps) {
 
   const deleteIncome = async (id: string) => {
     try {
-      const { error, count } = await supabase
+      const { data, error } = await supabase
         .from("client_financials")
-        .delete({ count: "exact" })
+        .delete()
         .eq("id", id)
-        .eq("transaction_type", "income");
+        .eq("transaction_type", "income")
+        .select("id");
 
       if (error) throw error;
 
-      if (!count) {
+      if (!data || data.length === 0) {
         toast({
           title: "Erro",
           description: "Receita não encontrada ou você não tem permissão para excluir.",


### PR DESCRIPTION
## Summary
- ensure the income deletion request selects the removed row so the confirmation logic works

## Testing
- npm run lint *(fails: npm install cannot fetch dependencies due to registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d576df53f083209d38b07db808effd