### PR TITLE
Include em_obra projects in assigned phase views

### DIFF
--- a/src/components/projects/UserPhasesView.tsx
+++ b/src/components/projects/UserPhasesView.tsx
@@ -121,7 +121,12 @@ export function UserPhasesView() {
         status: phase.status as UserPhase['status'],
         project: Array.isArray(phase.project) ? phase.project[0] : phase.project
       }));
-      setPhases(phasesData);
+      const allowedProjectStatuses = new Set(['em_andamento', 'em_obra']);
+      const activeProjectPhases = phasesData.filter(phase => {
+        const projectStatus = phase.project?.status;
+        return !projectStatus || allowedProjectStatuses.has(projectStatus);
+      });
+      setPhases(activeProjectPhases);
     } catch (error) {
       console.error('Erro ao carregar fases do usuário:', error);
       toast({

--- a/src/hooks/useUserProjects.ts
+++ b/src/hooks/useUserProjects.ts
@@ -22,6 +22,7 @@ interface UserPhase {
   project: {
     id: string;
     title: string;
+    status?: string;
   };
 }
 
@@ -147,7 +148,7 @@ export function useUserProjects() {
           status,
           allocated_hours,
           executed_hours,
-          project:projects(id, title)
+          project:projects(id, title, status)
         `)
         .eq('assigned_to', profileId)
         .order('created_at', { ascending: false });
@@ -171,7 +172,13 @@ export function useUserProjects() {
         project: Array.isArray(phase.project) ? phase.project[0] : phase.project
       }));
 
-      setPhases(processedPhases);
+      const allowedProjectStatuses = new Set(['em_andamento', 'em_obra']);
+      const activeProjectPhases = processedPhases.filter(phase => {
+        const projectStatus = phase.project?.status;
+        return !projectStatus || allowedProjectStatuses.has(projectStatus);
+      });
+
+      setPhases(activeProjectPhases);
 
       // Calcular horas trabalhadas
       const today = new Date();


### PR DESCRIPTION
## Summary
- ensure collaborator and coordinator phase lists keep projects with status **em_andamento** or **em_obra**
- update the shared user projects hook to surface project status data and apply the same active project filter

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f707f14483209d1219d0885221a0