### PR TITLE
Fix client document deletion

### DIFF
--- a/supabase/migrations/20250507120000_add_delete_policy_client_documents.sql
+++ b/supabase/migrations/20250507120000_add_delete_policy_client_documents.sql
@@ -1,0 +1,5 @@
+-- Permite que usuários autenticados excluam documentos de clientes
+CREATE POLICY "Authenticated users can delete client documents"
+ON public.client_documents
+FOR DELETE
+USING (auth.uid() IS NOT NULL);


### PR DESCRIPTION
## Summary
- allow client document deletion to proceed even when the storage file is missing and refresh local state
- add a Supabase policy so authenticated users can delete records from client_documents

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e30df338248320b6058e32d53eac41