### PR TITLE
Atualiza rótulo de role para colaborador

### DIFF
--- a/src/pages/UnifiedUserManagement.tsx
+++ b/src/pages/UnifiedUserManagement.tsx
@@ -676,7 +676,7 @@ export default function UnifiedUserManagement({ showHeader = true }: UnifiedUser
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="user">Usuário</SelectItem>
+                <SelectItem value="user">Colaborador</SelectItem>
                 <SelectItem value="supervisor">Supervisor</SelectItem>
                 <SelectItem value="coordenador">Coordenador</SelectItem>
                 <SelectItem value="admin">Admin</SelectItem>
@@ -936,13 +936,13 @@ export default function UnifiedUserManagement({ showHeader = true }: UnifiedUser
                       <SelectTrigger>
                         <SelectValue />
                       </SelectTrigger>
-                       <SelectContent>
-                         <SelectItem value="user">Usuário</SelectItem>
-                         <SelectItem value="supervisor">Supervisor</SelectItem>
-                         <SelectItem value="coordenador">Coordenador</SelectItem>
-                         <SelectItem value="marketing">Marketing</SelectItem>
-                         {isMasterAdmin && <SelectItem value="admin">Administrador</SelectItem>}
-                       </SelectContent>
+                      <SelectContent>
+                        <SelectItem value="user">Colaborador</SelectItem>
+                        <SelectItem value="supervisor">Supervisor</SelectItem>
+                        <SelectItem value="coordenador">Coordenador</SelectItem>
+                        <SelectItem value="marketing">Marketing</SelectItem>
+                        {isMasterAdmin && <SelectItem value="admin">Administrador</SelectItem>}
+                      </SelectContent>
                     </Select>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- rename the displayed label for the user role to Colaborador in the unified user management screen
- align the role selector in the creation dialog to also show Colaborador instead of Usuário

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3240e0240832092875622a77b0a37