### PR TITLE
Add marketing role to user management role selector

### DIFF
--- a/src/pages/UnifiedUserManagement.tsx
+++ b/src/pages/UnifiedUserManagement.tsx
@@ -679,6 +679,7 @@ export default function UnifiedUserManagement({ showHeader = true }: UnifiedUser
                 <SelectItem value="user">Colaborador</SelectItem>
                 <SelectItem value="supervisor">Supervisor</SelectItem>
                 <SelectItem value="coordenador">Coordenador</SelectItem>
+                <SelectItem value="marketing">Marketing</SelectItem>
                 <SelectItem value="admin">Admin</SelectItem>
               </SelectContent>
             </Select>


### PR DESCRIPTION
## Summary
- include the Marketing option in the user role selector within the user management settings tab

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e32867752c8320a7ff7187eb9c636d