### PR TITLE
Fix minutes dialog state initialization

### DIFF
--- a/src/pages/Agenda.tsx
+++ b/src/pages/Agenda.tsx
@@ -279,6 +279,11 @@ export default function Agenda() {
   const [activeTab, setActiveTab] = useState<'agenda' | 'atas'>('agenda');
   const [minutesTypeFilter, setMinutesTypeFilter] = useState<'all' | AgendaItem['tipo']>('all');
   const [minutesLocationFilter, setMinutesLocationFilter] = useState<'all' | string>('all');
+  const [isMinutesDialogOpen, setIsMinutesDialogOpen] = useState(false);
+  const [selectedMinutesMeetingId, setSelectedMinutesMeetingId] = useState("");
+  const [selectedMinutesMeeting, setSelectedMinutesMeeting] = useState<AgendaItem | null>(null);
+  const [minutesText, setMinutesText] = useState("");
+  const [isSavingMinutes, setIsSavingMinutes] = useState(false);
 
 
 


### PR DESCRIPTION
## Summary
- add missing state hooks to manage the minutes dialog and selected meeting data in Agenda page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e388de985c8320889980ece7187581