### PR TITLE
Document search_path lint issue for send_daily_whatsapp_agenda

### DIFF
--- a/supabase/lint_reports/send_daily_whatsapp_agenda.md
+++ b/supabase/lint_reports/send_daily_whatsapp_agenda.md
@@ -1,0 +1,23 @@
+# Function `public.send_daily_whatsapp_agenda` – Mutable `search_path`
+
+## Issue Summary
+- **Problem:** The function does not define a fixed `search_path`, so it inherits whatever `search_path` is active when it runs. This allows name resolution to be hijacked (for example, a malicious table or function in a different schema shadowing an expected object).
+- **Impact:** Because the function is `SECURITY DEFINER`, it runs with elevated privileges. A mutable `search_path` lets attackers escalate privileges by invoking unexpected objects.
+
+## Suggested Fixes
+1. **Set an explicit search path at the beginning of the function**:
+   ```sql
+   CREATE OR REPLACE FUNCTION public.send_daily_whatsapp_agenda()
+   RETURNS jsonb
+   LANGUAGE plpgsql
+   SECURITY DEFINER
+   SET search_path = public, pg_temp
+   AS $$
+   ...
+   $$;
+   ```
+   Include only the schemas that the function actually needs.
+2. **Schema-qualify all object references** (e.g., `public.daily_whatsapp_log`, `cron.schedule`) so that even if the `search_path` changes, the function still resolves objects safely.
+3. **Review other invocations** of this function (cron jobs or triggers) to ensure they do not depend on an implicit `search_path` and update them to use schema-qualified calls if necessary.
+
+Addressing the mutable `search_path` protects against name resolution attacks and aligns with lint/security best practices.


### PR DESCRIPTION
## Summary
- document the mutable search_path lint finding for public.send_daily_whatsapp_agenda
- outline security impact and recommended fixes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e38ac9c50c832082a3edb747f3c16e