### PR TITLE
Adicionar botão de registro de atas com busca de reuniões

### DIFF
--- a/src/pages/Agenda.tsx
+++ b/src/pages/Agenda.tsx
@@ -22,7 +22,8 @@ import {
   ChevronRight,
   X,
   Gift,
-  NotebookPen
+  NotebookPen,
+  Search
 } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -284,6 +285,7 @@ export default function Agenda() {
   const [selectedMinutesMeeting, setSelectedMinutesMeeting] = useState<AgendaItem | null>(null);
   const [minutesText, setMinutesText] = useState("");
   const [isSavingMinutes, setIsSavingMinutes] = useState(false);
+  const [minutesSearchTerm, setMinutesSearchTerm] = useState("");
 
 
 
@@ -648,6 +650,7 @@ export default function Agenda() {
       setSelectedMinutesMeetingId("");
       setSelectedMinutesMeeting(null);
       setMinutesText("");
+      setMinutesSearchTerm("");
     }
 
     setIsMinutesDialogOpen(open);
@@ -798,6 +801,32 @@ export default function Agenda() {
       return a.titulo.localeCompare(b.titulo, 'pt-BR');
     });
   }, [filteredAgendaForMinutes]);
+
+  const searchedMinutesMeetings = useMemo(() => {
+    const term = minutesSearchTerm.trim().toLowerCase();
+    if (!term) {
+      return sortedAgendaForMinutes;
+    }
+
+    return sortedAgendaForMinutes.filter(item => {
+      const comparableValues = [
+        item.titulo,
+        item.cliente,
+        getTipoLabel(item.tipo),
+        getLocationDisplay(item.local),
+        item.attendees_display,
+        formatDisplayDateRange(item.data, item.data_fim),
+        item.horario ? item.horario.substring(0, 5) : '',
+        item.horario_fim ? item.horario_fim.substring(0, 5) : '',
+        item.agenda_type === 'pessoal' ? 'pessoal' : 'compartilhada'
+      ];
+
+      return comparableValues.some(value => {
+        if (!value) return false;
+        return value.toLowerCase().includes(term);
+      });
+    });
+  }, [minutesSearchTerm, sortedAgendaForMinutes]);
 
   const minutesGroups = useMemo<MinutesGroup[]>(() => {
     const filtered = filteredAgendaForMinutes;
@@ -1837,28 +1866,83 @@ export default function Agenda() {
           </DialogHeader>
 
           <div className="space-y-6">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground" htmlFor="minutes-meeting-select">
-                Reunião
-              </label>
-              <Select
-                value={selectedMinutesMeetingId}
-                onValueChange={handleSelectMinutesMeeting}
-              >
-                <SelectTrigger id="minutes-meeting-select" className="h-11 w-full">
-                  <SelectValue placeholder="Selecione a reunião" />
-                </SelectTrigger>
-                <SelectContent className="max-h-72">
-                  {sortedAgendaForMinutes.map(meeting => (
-                    <SelectItem key={meeting.id} value={meeting.id}>
-                      {`${formatDisplayDateRange(meeting.data, meeting.data_fim)} • ${meeting.titulo}`}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground">
-                Os detalhes da reunião são preenchidos automaticamente após a seleção.
-              </p>
+            <div className="space-y-3">
+              <div className="space-y-1">
+                <label className="text-sm font-medium text-foreground" htmlFor="minutes-meeting-search">
+                  Buscar reunião
+                </label>
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    id="minutes-meeting-search"
+                    placeholder="Busque por título, cliente, local ou data"
+                    value={minutesSearchTerm}
+                    onChange={event => setMinutesSearchTerm(event.target.value)}
+                    className="pl-9"
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Clique em uma reunião para carregar os detalhes e registrar a ata.
+                </p>
+              </div>
+
+              <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
+                {searchedMinutesMeetings.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/10 p-4 text-center text-sm text-muted-foreground">
+                    Nenhuma reunião encontrada com os filtros e busca aplicados.
+                  </div>
+                ) : (
+                  searchedMinutesMeetings.map(meeting => {
+                    const isSelected = selectedMinutesMeetingId === meeting.id;
+                    return (
+                      <button
+                        key={meeting.id}
+                        type="button"
+                        onClick={() => handleSelectMinutesMeeting(meeting.id)}
+                        className={cn(
+                          "w-full rounded-lg border p-3 text-left transition-all hover:border-primary/50 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
+                          isSelected
+                            ? "border-primary bg-primary/10 shadow-sm"
+                            : "border-muted-foreground/20 bg-background"
+                        )}
+                      >
+                        <div className="flex flex-wrap items-start justify-between gap-2">
+                          <div className="space-y-1">
+                            <p className="text-sm font-semibold text-foreground">{meeting.titulo}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {formatDisplayDateRange(meeting.data, meeting.data_fim)}
+                              {meeting.horario && (
+                                <>
+                                  {' '}• {meeting.horario.substring(0, 5)}
+                                  {meeting.horario_fim && ` - ${meeting.horario_fim.substring(0, 5)}`}
+                                </>
+                              )}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {meeting.cliente || INTERNAL_MEETING_PLACEHOLDER} • {getLocationDisplay(meeting.local)}
+                            </p>
+                          </div>
+                          <div className="flex flex-col items-end gap-1">
+                            <Badge variant="secondary" className="bg-primary/10 text-primary border-primary/20">
+                              {getTipoLabel(meeting.tipo)}
+                            </Badge>
+                            <Badge
+                              variant="secondary"
+                              className={`text-xs ${
+                                meeting.agenda_type === 'pessoal'
+                                  ? 'bg-yellow-500/10 text-yellow-700 border-yellow-500/30'
+                                  : 'bg-green-500/10 text-green-700 border-green-500/30'
+                              }`}
+                            >
+                              {meeting.agenda_type === 'pessoal' ? 'Pessoal' : 'Compartilhado'}
+                            </Badge>
+                          </div>
+                        </div>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
             </div>
 
             {selectedMinutesMeeting && (
@@ -2062,6 +2146,21 @@ export default function Agenda() {
 
         <TabsContent value="atas" className="space-y-4 md:space-y-6">
 
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-foreground">Atas de reunião</h2>
+              <p className="text-sm text-muted-foreground">
+                Centralize o registro das decisões das reuniões da agenda.
+              </p>
+            </div>
+            <Button
+              className="btn-hero h-11 w-full sm:w-auto"
+              onClick={() => handleMinutesDialogOpenChange(true)}
+            >
+              <NotebookPen className="mr-2 h-4 w-4" />
+              Registrar ata
+            </Button>
+          </div>
 
           <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-3">
             <Select


### PR DESCRIPTION
## Summary
- adiciona um botão dedicado para registrar atas diretamente na aba de atas
- insere campo de busca e lista das reuniões da agenda dentro do modal de registro
- mantém destaque visual para a reunião selecionada ao carregar os detalhes da ata

## Testing
- npm run build *(falhou: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e38f6e0b488320ad97904104c8c9b7