### PR TITLE
Add general internal chat room

### DIFF
--- a/src/hooks/useInternalChatContacts.ts
+++ b/src/hooks/useInternalChatContacts.ts
@@ -5,12 +5,15 @@ import { useAuth } from '@/state/auth';
 export interface InternalContact {
   id: string;
   name: string;
-  role: string;
+  role?: string;
   unreadCount: number;
   lastMessage?: string;
   lastMessageTime?: string;
   isOnline?: boolean;
+  isGroup?: boolean;
 }
+
+export const GENERAL_CHAT_ID = "general-internal-chat";
 
 export function useInternalChatContacts() {
   const { user } = useAuth();
@@ -40,68 +43,83 @@ export function useInternalChatContacts() {
 
       if (profileError) {
         console.error('Erro ao buscar profiles:', profileError);
-        setContacts([]);
-        setLoading(false);
-        return;
       }
 
-      if (!allProfiles || allProfiles.length === 0) {
-        setContacts([]);
-        setLoading(false);
-        return;
+      const safeProfiles = allProfiles ?? [];
+
+      const contactsWithMessages = safeProfiles
+        ? await Promise.all(
+            safeProfiles.map(async (profile) => {
+              // Buscar última mensagem (enviada ou recebida)
+              const { data: lastMessages, error: msgError } = await supabase
+                .from('messages')
+                .select('*')
+                .or(`and(from_user_id.eq.${user.id},to_user_id.eq.${profile.user_id}),and(from_user_id.eq.${profile.user_id},to_user_id.eq.${user.id})`)
+                .order('created_at', { ascending: false })
+                .limit(1);
+
+              if (msgError) {
+                console.error('Erro ao buscar mensagens:', msgError);
+              }
+
+              const lastMessage = lastMessages && lastMessages.length > 0 ? lastMessages[0] : null;
+
+              // Contar mensagens não lidas (recebidas deste contato)
+              const { data: unreadMessages, error: unreadError } = await supabase
+                .from('messages')
+                .select('id')
+                .eq('from_user_id', profile.user_id)
+                .eq('to_user_id', user.id)
+                .is('viewed_at', null);
+
+              if (unreadError) {
+                console.error('Erro ao buscar não lidas:', unreadError);
+              }
+
+              const unreadCount = unreadMessages?.length || 0;
+
+              return {
+                id: profile.user_id,
+                name: profile.name || profile.email || 'Usuário',
+                role: profile.role || 'user',
+                unreadCount,
+                lastMessage: lastMessage?.message || '',
+                lastMessageTime: lastMessage?.created_at || '',
+                isOnline: Math.random() > 0.5, // TODO: Implementar status real
+              } as InternalContact;
+            })
+          )
+        : [];
+
+      // Buscar informações do chat geral
+      const { data: lastGroupMessages, error: groupError } = await supabase
+        .from('group_messages')
+        .select('message, created_at')
+        .order('created_at', { ascending: false })
+        .limit(1);
+
+      if (groupError) {
+        console.error('Erro ao buscar mensagens do grupo:', groupError);
       }
 
-      // Buscar última mensagem com cada usuário
-      const contactsWithMessages = await Promise.all(
-        allProfiles.map(async (profile) => {
-          // Buscar última mensagem (enviada ou recebida)
-          const { data: lastMessages, error: msgError } = await supabase
-            .from('messages')
-            .select('*')
-            .or(`and(from_user_id.eq.${user.id},to_user_id.eq.${profile.user_id}),and(from_user_id.eq.${profile.user_id},to_user_id.eq.${user.id})`)
-            .order('created_at', { ascending: false })
-            .limit(1);
+      const generalContact: InternalContact = {
+        id: GENERAL_CHAT_ID,
+        name: 'Chat Geral',
+        role: 'group',
+        unreadCount: 0,
+        lastMessage: lastGroupMessages?.[0]?.message || '',
+        lastMessageTime: lastGroupMessages?.[0]?.created_at || '',
+        isGroup: true,
+      };
 
-          if (msgError) {
-            console.error('Erro ao buscar mensagens:', msgError);
-          }
-
-          const lastMessage = lastMessages && lastMessages.length > 0 ? lastMessages[0] : null;
-
-          // Contar mensagens não lidas (recebidas deste contato)
-          const { data: unreadMessages, error: unreadError } = await supabase
-            .from('messages')
-            .select('id')
-            .eq('from_user_id', profile.user_id)
-            .eq('to_user_id', user.id)
-            .is('viewed_at', null);
-
-          if (unreadError) {
-            console.error('Erro ao buscar não lidas:', unreadError);
-          }
-
-          const unreadCount = unreadMessages?.length || 0;
-
-          return {
-            id: profile.user_id,
-            name: profile.name || profile.email || 'Usuário',
-            role: profile.role || 'user',
-            unreadCount,
-            lastMessage: lastMessage?.message || '',
-            lastMessageTime: lastMessage?.created_at || '',
-            isOnline: Math.random() > 0.5, // TODO: Implementar status real
-          } as InternalContact;
-        })
-      );
-
-      // Ordenar por última mensagem
+      // Ordenar contatos individuais por última mensagem
       contactsWithMessages.sort((a, b) => {
         if (!a.lastMessageTime) return 1;
         if (!b.lastMessageTime) return -1;
         return new Date(b.lastMessageTime).getTime() - new Date(a.lastMessageTime).getTime();
       });
 
-      setContacts(contactsWithMessages);
+      setContacts([generalContact, ...contactsWithMessages]);
     } catch (error) {
       console.error('Erro ao carregar contatos:', error);
       setContacts([]);

--- a/supabase/migrations/20251016120000_add_group_chat.sql
+++ b/supabase/migrations/20251016120000_add_group_chat.sql
@@ -1,0 +1,39 @@
+-- Create table to store messages from the internal general chat
+create table if not exists public.group_messages (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  message text not null,
+  created_at timestamptz not null default now(),
+  user_name text
+);
+
+alter table public.group_messages enable row level security;
+
+create policy if not exists "Authenticated users can read group messages"
+  on public.group_messages
+  for select
+  to authenticated
+  using (true);
+
+create policy if not exists "Authenticated users can post group messages"
+  on public.group_messages
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create index if not exists idx_group_messages_created_at
+  on public.group_messages (created_at desc);
+
+alter table public.group_messages replica identity full;
+
+-- Ensure the table is part of realtime publications if available
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_publication
+    WHERE pubname = 'supabase_realtime'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.group_messages;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add a shared "Chat Geral" contact that automatically loads for all collaborators in the internal chat
- support sending and receiving group messages with realtime updates and name labels in the chat UI
- create the Supabase `group_messages` table with RLS policies and realtime publication for the new room

## Testing
- npm run lint *(fails: missing local npm packages in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3983acbc48320960c8ec98accd2a5